### PR TITLE
Do not override output handle in Vty config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist-newstyle
+.stack-work

--- a/src/Vty.hs
+++ b/src/Vty.hs
@@ -24,5 +24,5 @@ withVty action = do
     tty <- handleToFd ttyHandle
 #endif
     defSettings <- Vty.defaultSettings
-    vty <- Vty.mkVtyWithSettings Vty.defaultConfig defSettings{Vty.settingInputFd = tty, Vty.settingOutputFd = tty}
+    vty <- Vty.mkVtyWithSettings Vty.defaultConfig defSettings{Vty.settingInputFd = tty}
     action vty


### PR DESCRIPTION
- would not work on windows
- unnecessary on linux

Fixes #5