### PR TITLE
App (config): dump current settings of viewer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,0 @@
-run-monalog:
-	cabal run monalog ./fixtures/raw.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+run-monalog:
+	cabal run monalog ./fixtures/raw.json

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -67,13 +67,13 @@ viewerArgs = do
           _ -> Nothing
      in optional . option reader $ i
 
-  prefix <- 
+  prefix <-
     let i = long "prefix" <> short 'p'
         reader = maybeReader \case
           "empty" -> Just Empty
           "kube-tm" -> Just KubeTm
           _ -> Nothing
-    in optional . option reader $ i
+     in optional . option reader $ i
 
   pure $ AppArguments{..}
 
@@ -146,8 +146,9 @@ createConfig force path = do
         , format = Last $ Just Json
         , copyMethod = Last $ Just Native
         , copyCommand = Last Nothing
+        , prefix = Last Nothing
         }
   case result of
-    Left Config.FileExists -> putStrLn $ "Error saving a config: file exists. Use --force to overwrite."
+    Left (Config.FileExists path) -> putStrLn $ "Error saving a config: file " <> path <> " exists. Use --force to overwrite."
     Left (Config.UnexpectedError e) -> putStrLn $ "Error saving a config: " <> show e
     Right _ -> putStrLn $ "Config created at " <> path <> configName

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -118,7 +119,7 @@ main =
         \case
           GetLocalConfigPath -> putStrLn configName
           GetGlobalConfigPath -> globalConfigDirPath >>= putStrLn . (<> configName)
-          CreateLocalConfig force -> createConfig force ""
+          CreateLocalConfig force -> createConfig force configName
           CreateGlobalConfig force -> globalConfigDirPath >>= createConfig force
       do app
 
@@ -135,31 +136,18 @@ copyMethodReader = maybeReader \case
 
 createConfig :: Bool -> FilePath -> IO ()
 createConfig force path = do
-  let filePath = path <> configName
-  doesConfigExist <- catch
-    do withFile filePath ReadMode (const (pure True))
-    do pure . not . isDoesNotExistErrorType . ioeGetErrorType
-  if not doesConfigExist || force
-    then do
-      createDirectoryIfMissing True path
-      bool appendFile writeFile doesConfigExist filePath $
-        unlines
-          [ "# Field in which invalid json will be written. Useful only for json format."
-          , "defaultField: \"message\""
-          , ""
-          , "# json / csv"
-          , "format: json"
-          , ""
-          , "# Fields selected by default"
-          , "fields:"
-          , "  - message"
-          , "  - severity"
-          , ""
-          , "# osc52 / native"
-          , "copyMethod: native"
-          , ""
-          , "# Command to copy with `native` copy method. Must take copied string from stdin"
-          , "copyCommand: null"
-          ]
-      putStrLn $ "Config created at " <> filePath
-    else putStrLn "Config already exists. To overwrite use --force"
+  result <-
+    dumpConfigTo
+      path
+      force
+      AppConfig
+        { defaultField = Last $ Just "message"
+        , fields = Last $ Just ["message", "severity"]
+        , format = Last $ Just Json
+        , copyMethod = Last $ Just Native
+        , copyCommand = Last Nothing
+        }
+  case result of
+    Left Config.FileExists -> putStrLn $ "Error saving a config: file exists. Use --force to overwrite."
+    Left (Config.UnexpectedError e) -> putStrLn $ "Error saving a config: " <> show e
+    Right _ -> putStrLn $ "Config created at " <> path <> configName

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -1,6 +1,6 @@
 module Config where
 
-import Control.Exception (catch)
+import Control.Exception (SomeException, catch, try)
 import Control.Monad ((>=>))
 import Data.Aeson (withText)
 import Data.ByteString qualified as Bytes
@@ -9,12 +9,13 @@ import Data.Maybe (fromMaybe)
 import Data.Monoid (Last (..))
 import Data.Text (Text)
 import Data.Text qualified as Text
-import Data.Yaml (decodeEither', prettyPrintParseException)
-import Data.Yaml.Aeson (FromJSON (parseJSON))
+import Data.Yaml (decodeEither', encodeFile, prettyPrintParseException)
+import Data.Yaml.Aeson (FromJSON (parseJSON), ToJSON (toJSON), Value (String))
 import GHC.Generics (Generic)
 import GHC.IO (throwIO)
 import System (System (..), currentOs)
 import System.Directory
+import System.FilePath
 import System.IO.Error
 import Type.Event (FatalError (..))
 import Widgets.LogView.Types (CopyMethod)
@@ -35,6 +36,12 @@ instance FromJSON Format where
     "json" -> pure Json
     _ -> fail "Failed to parse format"
 
+instance ToJSON Format where
+  toJSON =
+    String . \case
+      Csv -> "csv"
+      Json -> "json"
+
 data ConfigType = Local | Global | All
 
 data AppConfig = AppConfig
@@ -45,7 +52,7 @@ data AppConfig = AppConfig
   , copyCommand :: Last String
   , prefix :: Last Prefix
   }
-  deriving (Generic, FromJSON)
+  deriving (Generic, FromJSON, ToJSON)
 
 instance Semigroup AppConfig where
   a <> b =
@@ -64,7 +71,7 @@ instance Monoid AppConfig where
     empty :: Last a
     empty = Last Nothing
 
-loadConfig :: Maybe String -> Maybe ConfigType -> IO AppConfig
+loadConfig :: Maybe FilePath -> Maybe ConfigType -> IO AppConfig
 loadConfig userConfigPath = maybe
   do (<>) <$> loadGlobal <*> loadLocal
   do
@@ -92,6 +99,26 @@ loadConfig userConfigPath = maybe
       else throwIOError e
 
   throwIOError = throwFatalError . ioeGetErrorString
+
+data DumpError = FileExists | UnexpectedError Text
+
+-- | Dumps given config to local file path as yaml
+dumpConfigToLocal :: AppConfig -> IO (Either DumpError ())
+dumpConfigToLocal = dumpConfigTo configName True
+
+-- | Dumps given config to given file path as yaml
+dumpConfigTo :: FilePath -> Bool -> AppConfig -> IO (Either DumpError ())
+dumpConfigTo path force config = do
+  result <- try @SomeException $ do
+    createDirectoryIfMissing True $ takeDirectory path
+    exists <- doesFileExist $ takeFileName path
+    if not force && exists
+      then pure $ Left FileExists
+      else Right <$> encodeFile path config
+  pure $ case result of
+    Left ex -> Left $ UnexpectedError $ Text.pack $ show ex
+    Right (Left e) -> Left e
+    Right _ -> Right ()
 
 globalPath :: IO FilePath
 globalPath = globalConfigDirPath <&> (<> configName)

--- a/src/Handler.hs
+++ b/src/Handler.hs
@@ -47,7 +47,7 @@ handleEvent ch e = do
         callLogsViewWidget (LogsView.NewLog l)
       FilteredLogs ls -> forM_ ls \l -> do
         callLogsViewWidget (LogsView.FilteredLog l)
-      ResetCopied -> callStatusBarWidget StatusBar.ResetCopied
+      ResetCopied -> callStatusBarWidget StatusBar.ResetStatus
     B.MouseDown (WidgetName name) V.BLeft _ loc' | ms == Up -> do
       absoluteLoc <- translateToAbsolute (WidgetName name) loc'
       let canClick = case activeWidget of
@@ -249,7 +249,8 @@ handleEvent ch e = do
               do \mw -> LogsView.SelectedField{width = mw, ..}
               do Map.lookup path paths
             _ -> f
-      , holdMouse = \n l -> #mouseState .= Down n l
+      , Fields.configSaved = callStatusBarWidget StatusBar.ConfigSaved
+      , Fields.holdMouse = \n l -> #mouseState .= Down n l
       }
 
   activateLogsView = #activeWidget .= [AS.LogsWidgetName]

--- a/src/Handler.hs
+++ b/src/Handler.hs
@@ -263,8 +263,8 @@ handleEvent format config ch e = do
               , fields =
                   Last . Just $
                     fields <&> \selectedField -> case selectedField.field of
-                      Raw -> "raw"
-                      Timestamp -> "timestamp"
+                      Raw -> "@raw"
+                      Timestamp -> "@timestamp"
                       Field path -> drawPath path
               , copyMethod = config.copyMethod
               , copyCommand = config.copyCommand

--- a/src/Handler.hs
+++ b/src/Handler.hs
@@ -3,17 +3,19 @@ module Handler (handleEvent) where
 import Brick qualified as B
 import Brick.BChan qualified as B
 import Conduit (MonadIO (..))
+import Config
 import Control.Exception (throwIO)
 import Control.Lens
 import Control.Monad (forM_, when)
 import Data.Generics.Labels ()
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromJust)
+import Data.Monoid (Last (..))
 import Graphics.Vty qualified as V
 import Type.AppState
 import Type.AppState qualified as AS
 import Type.Event
-import Type.Field (Field (..))
+import Type.Field (Field (..), drawPath)
 import Type.Name
 import Type.Name qualified as N
 import Widgets.Dialog.Handler qualified as Dialog
@@ -31,8 +33,8 @@ import Widgets.StatusBar.Handler qualified as StatusBar
 import Widgets.StatusBar.Types qualified as StatusBar
 import Widgets.Types (PackedLens' (PackedLens'))
 
-handleEvent :: B.BChan Event -> B.BrickEvent Name Event -> B.EventM Name AppState ()
-handleEvent ch e = do
+handleEvent :: Format -> AppConfig -> B.BChan Event -> B.BrickEvent Name Event -> B.EventM Name AppState ()
+handleEvent format config ch e = do
   ms <- use #mouseState
 
   activeWidget <- use #activeWidget
@@ -249,7 +251,25 @@ handleEvent ch e = do
               do \mw -> LogsView.SelectedField{width = mw, ..}
               do Map.lookup path paths
             _ -> f
-      , Fields.configSaved = callStatusBarWidget StatusBar.ConfigSaved
+      , Fields.configSaved = \case
+          Fields.SavedSuccessfully -> callStatusBarWidget StatusBar.ConfigSaved
+          Fields.SaveErrorHappened err -> errorDialog $ "Error during saving of config: " <> err
+      , Fields.getConfig = do
+          fields <- use $ #logsView . #selectedFields
+          pure
+            AppConfig
+              { defaultField = config.defaultField
+              , format = Last $ Just format
+              , fields =
+                  Last . Just $
+                    fields <&> \selectedField -> case selectedField.field of
+                      Raw -> "raw"
+                      Timestamp -> "timestamp"
+                      Field path -> drawPath path
+              , copyMethod = config.copyMethod
+              , copyCommand = config.copyCommand
+              , prefix = config.prefix
+              }
       , Fields.holdMouse = \n l -> #mouseState .= Down n l
       }
 

--- a/src/Type/AppState.hs
+++ b/src/Type/AppState.hs
@@ -5,6 +5,7 @@ import Brick.Widgets.Edit qualified as B
 import Consts
 import Control.Lens
 import Data.Map.Strict qualified as Map
+import Data.Maybe (fromMaybe)
 import Data.String (IsString (..))
 import GHC.Generics
 import Type.Field (Field (..))
@@ -48,7 +49,12 @@ initialState :: Maybe String -> Maybe CopyMethod -> Maybe [Field] -> IO AppState
 initialState copyCmd copyMethod defaultFields = do
   let defaultWidth = MaxWidth 1
   initialLogsView <- initLogsView (maybe [] (map (`SelectedField` defaultWidth)) defaultFields)
-  let fields = maybe initialFields (Map.fromList . map (,FieldState{isSelected = True, maxWidth = defaultWidth})) defaultFields
+  let fields =
+        flip Map.union initialFields
+          . Map.fromList
+          . map (,FieldState{isSelected = True, maxWidth = defaultWidth})
+          . fromMaybe mempty
+          $ defaultFields
   pure
     AppState
       { dialogWidget = Nothing

--- a/src/Type/AppState.hs
+++ b/src/Type/AppState.hs
@@ -18,7 +18,7 @@ import Widgets.Fields.Types
 import Widgets.LogView.Types (CopyMethod, LogViewWidget, emptyLogWidget)
 import Widgets.LogsView.Types
 import Widgets.Query.Types
-import Widgets.StatusBar.Types (StatusBarWidget (..))
+import Widgets.StatusBar.Types (StatusBarStatus (..), StatusBarWidget (..))
 
 data MouseState = Up | Down N.Name B.Location
   deriving (Eq, Show)
@@ -69,7 +69,7 @@ initialState copyCmd copyMethod defaultFields = do
             , topLine = initialTopLine
             , followLogs = initialFollowLogs
             , logViewPosition = LogViewPositionRight
-            , copied = False
+            , status = Idle
             }
       , fieldsView =
           FieldsWidget

--- a/src/Type/Name.hs
+++ b/src/Type/Name.hs
@@ -39,6 +39,7 @@ data FieldsWidgetName
   = FieldWidgetItself
   | FieldWidgetField Field
   | FieldWidgetLayoutButton
+  | FieldWidgetSaveConfig
   | FieldWidgetViewport
   | FieldWidgetBorder
   | FieldWidgetHScrollBar B.ClickableScrollbarElement

--- a/src/Widgets/Fields/Handler.hs
+++ b/src/Widgets/Fields/Handler.hs
@@ -22,14 +22,17 @@ import Type.WidgetSize (WidgetSize (..))
 import Widgets.Fields.Types
 import Widgets.Scrollbar.Horizontal qualified as HScroll
 
-fieldsWidgetHandleEvent :: Lens' s FieldsWidget -> FieldsWidgetCallbacks s -> FieldWidgetEvent -> B.EventM Name s ()
+fieldsWidgetHandleEvent ::
+  Lens' s FieldsWidget ->
+  FieldsWidgetCallbacks s ->
+  FieldWidgetEvent ->
+  B.EventM Name s ()
 fieldsWidgetHandleEvent widgetState cb@FieldsWidgetCallbacks{..} = \case
   NewLog l -> handleNewLog widgetState cb l
   Click (FieldWidgetHScrollBar B.SBBar) loc ->
     holdMouse (mkName $ FieldWidgetHScrollBar B.SBBar) loc
   Click FieldWidgetBorder loc@(B.Location (c, _)) -> do
     B.Extent{extentUpperLeft = B.Location (lc, _)} <- fromJust <$> B.lookupExtent (mkName FieldWidgetItself)
-
     widgetState . #width .= Manual (c - lc)
     holdMouse (mkName FieldWidgetBorder) loc
   Move (FieldWidgetHScrollBar B.SBBar) prevLoc newLoc -> do
@@ -45,6 +48,9 @@ fieldsWidgetHandleEvent widgetState cb@FieldsWidgetCallbacks{..} = \case
       Flatten -> Nested
       Nested -> Flatten
     B.invalidateCache
+  Click FieldWidgetSaveConfig _ -> do
+    cb.configSaved
+    pure ()
   Click (FieldWidgetField field) _ -> do
     fields <- use $ widgetState . #fields
     let isFieldUpdating k = case (field, k) of

--- a/src/Widgets/Fields/Types.hs
+++ b/src/Widgets/Fields/Types.hs
@@ -31,6 +31,7 @@ data FieldsWidgetCallbacks s = FieldsWidgetCallbacks
   , fieldUnselected :: Field -> B.EventM Name s ()
   , fieldsChangedMaxSize :: Map.Map Path MaxWidth -> B.EventM Name s ()
   , holdMouse :: Name -> B.Location -> B.EventM Name s ()
+  , configSaved :: B.EventM Name s ()
   }
 
 data FieldWidgetEvent

--- a/src/Widgets/Fields/Types.hs
+++ b/src/Widgets/Fields/Types.hs
@@ -1,8 +1,10 @@
 module Widgets.Fields.Types where
 
 import Brick qualified as B
+import Config (AppConfig)
 import Data.Aeson (ToJSON)
 import Data.Map.Strict qualified as Map
+import Data.Text (Text)
 import GHC.Generics (Generic)
 import Type.Field (Field (..), Path)
 import Type.Log (Log)
@@ -26,12 +28,15 @@ data FieldsWidget = FieldsWidget
 
 data FieldsViewLayout = Flatten | Nested
 
+data ConfigSavingResult = SavedSuccessfully | SaveErrorHappened Text
+
 data FieldsWidgetCallbacks s = FieldsWidgetCallbacks
   { fieldSelected :: MaxWidth -> Field -> B.EventM Name s ()
   , fieldUnselected :: Field -> B.EventM Name s ()
   , fieldsChangedMaxSize :: Map.Map Path MaxWidth -> B.EventM Name s ()
   , holdMouse :: Name -> B.Location -> B.EventM Name s ()
-  , configSaved :: B.EventM Name s ()
+  , configSaved :: ConfigSavingResult -> B.EventM Name s ()
+  , getConfig :: B.EventM Name s AppConfig
   }
 
 data FieldWidgetEvent

--- a/src/Widgets/Fields/Ui.hs
+++ b/src/Widgets/Fields/Ui.hs
@@ -6,6 +6,7 @@ import Data.Aeson.Key qualified as Key
 import Data.Foldable qualified as F
 import Data.Function ((&))
 import Data.Generics.Labels ()
+import Data.List.NonEmpty qualified as NE
 import Data.Map.Strict qualified as Map
 import Data.Maybe (mapMaybe)
 import Data.Text qualified as Text
@@ -70,9 +71,10 @@ fieldsWidgetDraw FieldsWidget{..} =
 
   contentWidth =
     Map.toList fields
-      & map (Text.length . drawLogsViewColumnHeaderTxt . fst)
-      & maximum
-      & (+ 6)
+      & NE.nonEmpty
+      & fmap (NE.map (Text.length . drawLogsViewColumnHeaderTxt . fst))
+      & fmap (maximum . NE.toList)
+      & maybe 6 (+ 6)
 
   drawButton n path k isSelected =
     B.hBox

--- a/src/Widgets/Fields/Ui.hs
+++ b/src/Widgets/Fields/Ui.hs
@@ -34,6 +34,7 @@ fieldsWidgetDraw FieldsWidget{..} =
           . B.viewport (mkName FieldWidgetViewport) B.Both
           . B.hLimit contentWidth
           $ B.vBox fieldsWidgets
+      , B.clickable (mkName FieldWidgetSaveConfig) $ B.txt "[Save]"
       ]
  where
   recMap = buildRecMap fields

--- a/src/Widgets/LogView/Types.hs
+++ b/src/Widgets/LogView/Types.hs
@@ -2,7 +2,7 @@ module Widgets.LogView.Types where
 
 import Brick qualified as B
 import Brick.Widgets.Edit qualified as B
-import Data.Aeson (FromJSON (..), Value (..), withText)
+import Data.Aeson (FromJSON (..), ToJSON (..), Value (..), withText)
 import Data.Text (Text)
 import GHC.Exts (IsList (..))
 import GHC.Generics
@@ -31,6 +31,12 @@ instance FromJSON CopyMethod where
     "osc52" -> pure Osc52
     "native" -> pure Native
     _ -> fail "Failed to parse copy method"
+
+instance ToJSON CopyMethod where
+  toJSON =
+    String . \case
+      Osc52 -> "osc52"
+      Native -> "native"
 
 emptyLogWidget :: LogViewWidget
 emptyLogWidget =

--- a/src/Widgets/StatusBar/Types.hs
+++ b/src/Widgets/StatusBar/Types.hs
@@ -16,9 +16,14 @@ data StatusBarWidget = StatusBarWidget
   , isEditorActive :: Bool
   , logViewPosition :: LogViewPosition
   , followLogs :: Bool
-  , copied :: Bool
+  , status :: StatusBarStatus
   }
   deriving (Generic)
+
+data StatusBarStatus
+  = Idle
+  | JustCopied
+  | JustSavedConfig
 
 data StatusBarWidgetEvent
   = NewLog
@@ -28,8 +33,9 @@ data StatusBarWidgetEvent
   | Key V.Key [V.Modifier]
   | ResetFollow
   | SetCopied
-  | ResetCopied
+  | ResetStatus
   | ActivateEditor
+  | ConfigSaved
 
 data StatusBarWidgetCallbacks s = StatusBarWidgetCallbacks
   { goToTop :: B.EventM Name s ()

--- a/src/Widgets/StatusBar/Ui.hs
+++ b/src/Widgets/StatusBar/Ui.hs
@@ -24,7 +24,10 @@ statusBarWidgetDraw StatusBarWidget{..} =
     , B.txt " "
     , B.padLeft B.Max $
         B.hBox
-          [ if copied then B.txt "Copied!" else B.emptyWidget
+          [ case status of
+              Idle -> B.emptyWidget
+              JustCopied -> B.txt "Copied!"
+              JustSavedConfig -> B.txt "Config saved!"
           , B.txt " "
           , B.hLimit (succ . sum . map Text.length . B.getEditContents $ topLineEditor) $
               B.renderEditor (B.hBox . map B.txt) isEditorActive topLineEditor


### PR DESCRIPTION
Adds basic support of dumping of current settings (mostly a selected fields) to yaml local config file.
All other fields are captured from config being parsed on startup.

By default generates local config only for now - but perhaps worth to add a choice via dialog.